### PR TITLE
Get rid of the response buffer

### DIFF
--- a/simple-smt.cabal
+++ b/simple-smt.cabal
@@ -23,6 +23,7 @@ library
   build-depends:       base >=4.8 && <10,
                        async,
                        bytestring >= 0.10,
+                       extra >= 1.7,
                        typed-process 
   default-language:    Haskell2010
 


### PR DESCRIPTION
I implemented something similar to [`hGetContentsSizeHint`](https://hackage.haskell.org/package/bytestring-0.11.3.1/docs/src/Data.ByteString.html#hGetContentsSizeHint) in the `Process` backend so as to get rid of the `response` field in `Solver.Backend`. 

I'm not sure of the implementation though, as there is still the problem of ensuring that the full output gets written before it starts being read. It should be ok if the solver always ends its output with an EOF and `hGet` waits for an EOF. But I'm not sure that `hGet` is the right function for this, I used it because I wanted to use something provided by the `bytestring` library.