### PR TITLE
`Solver.Process`: set handle options

### DIFF
--- a/src/SimpleSMT/Solver/Process.hs
+++ b/src/SimpleSMT/Solver/Process.hs
@@ -72,7 +72,8 @@ new exe args logger = do
   return $ SolverProcess solverProcess solverErrorReader
   where
     createLoggedPipe =
-      mkPipeStreamSpec $ \_ h ->
+      mkPipeStreamSpec $ \_ h -> do
+        hSetBinaryMode h True
         return
           ( h
           , hClose h `X.catch` \ex ->


### PR DESCRIPTION
The documentation for [`hPutBuilder`](https://hackage.haskell.org/package/bytestring-0.11.3.1/docs/Data-ByteString-Builder.html#v:hPutBuilder) says that the handle we use it on should be set to binary mode and use block buffering. This PR implements this for the `Process` backend, as SMTLib2 commands are sent using `hPutBuffer` on the process' input handle.

At the time of writing I only enabled binary mode on all of the process handles (not just the input handle). My understanding is that we're using `ByeteString`s so character encoding and decoding isn't necessary, and binary mode is faster than text mode.
I haven't set the buffering mode to block buffering though as I'm unsure of 1) what that means performance-wise, 2) what the default buffering mode of the handles created by `createProcess` are, and 3) whether line buffering may be more relevant here we only read and write full lines anyways. Let me know if you know more about this !