### PR TITLE
Add Nix flake and HLS setup

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,41 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1667395993,
+        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1669927173,
+        "narHash": "sha256-Z7rSKzC5OuWv5Q7RRNQPZb0jVJRJk0BJB6/fGZzaAIU=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "9063accddd2e68dcc71032459a58399e977374c9",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -15,6 +15,7 @@
       pkgs = nixpkgs.legacyPackages.${system};
       hpkgs = pkgs.haskellPackages;
       simple-smt = hpkgs.callCabal2nix "simple-smt" ./. {};
+      simple-smt-tests = hpkgs.callCabal2nix "simple-smt-tests" ./tests {};
       simple-smt-z3 = hpkgs.callCabal2nix "simple-smt-z3" ./Z3 {};
     in {
       formatter = pkgs.alejandra;
@@ -22,9 +23,8 @@
         default = hpkgs.shellFor {
           packages = p: [
             simple-smt
-            ## TODO fails on the import of simple-smt-tests
-            ## Should simple-smt-tests be declared as a library?
-            # simple-smt-z3
+            simple-smt-tests
+            simple-smt-z3
           ];
           withHoogle = true;
           buildInputs =

--- a/flake.nix
+++ b/flake.nix
@@ -16,7 +16,9 @@
       hpkgs = pkgs.haskellPackages;
       simple-smt = hpkgs.callCabal2nix "simple-smt" ./. {};
       simple-smt-tests = hpkgs.callCabal2nix "simple-smt-tests" ./tests {};
-      simple-smt-z3 = hpkgs.callCabal2nix "simple-smt-z3" ./Z3 {};
+      simple-smt-z3 = hpkgs.callCabal2nix "simple-smt-z3" ./Z3 {
+        inherit simple-smt-tests;
+      };
     in {
       formatter = pkgs.alejandra;
       devShells = {

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,40 @@
+{
+  inputs.flake-utils.url = github:numtide/flake-utils;
+
+  nixConfig = {
+    # Needed by callCabal2nix
+    allow-import-from-derivation = true;
+  };
+
+  outputs = {
+    self,
+    nixpkgs,
+    flake-utils,
+  }:
+    flake-utils.lib.eachSystem ["x86_64-linux"] (system: let
+      pkgs = nixpkgs.legacyPackages.${system};
+      hpkgs = pkgs.haskellPackages;
+      simple-smt = hpkgs.callCabal2nix "simple-smt" ./. {};
+      simple-smt-z3 = hpkgs.callCabal2nix "simple-smt-z3" ./Z3 {};
+    in {
+      formatter = pkgs.alejandra;
+      devShells = {
+        default = hpkgs.shellFor {
+          packages = p: [
+            simple-smt
+            ## TODO fails on the import of simple-smt-tests
+            ## Should simple-smt-tests be declared as a library?
+            # simple-smt-z3
+          ];
+          withHoogle = true;
+          buildInputs =
+            (with hpkgs; [
+              cabal-install
+              hlint
+              haskell-language-server
+            ])
+            ++ [pkgs.z3];
+        };
+      };
+    });
+}

--- a/flake.nix
+++ b/flake.nix
@@ -11,32 +11,41 @@
     nixpkgs,
     flake-utils,
   }:
-    flake-utils.lib.eachSystem ["x86_64-linux"] (system: let
-      pkgs = nixpkgs.legacyPackages.${system};
-      hpkgs = pkgs.haskellPackages;
-      simple-smt = hpkgs.callCabal2nix "simple-smt" ./. {};
-      simple-smt-tests = hpkgs.callCabal2nix "simple-smt-tests" ./tests {};
-      simple-smt-z3 = hpkgs.callCabal2nix "simple-smt-z3" ./Z3 {
-        inherit simple-smt-tests;
-      };
-    in {
-      formatter = pkgs.alejandra;
-      devShells = {
-        default = hpkgs.shellFor {
-          packages = p: [
-            simple-smt
-            simple-smt-tests
-            simple-smt-z3
-          ];
-          withHoogle = true;
-          buildInputs =
-            (with hpkgs; [
-              cabal-install
-              hlint
-              haskell-language-server
-            ])
-            ++ [pkgs.z3];
+    with flake-utils.lib;
+      eachSystem [system.x86_64-linux] (system: let
+        pkgs = nixpkgs.legacyPackages.${system};
+        hpkgs = pkgs.haskellPackages;
+        simple-smt = hpkgs.callCabal2nix "simple-smt" ./. {};
+        simple-smt-tests = hpkgs.callCabal2nix "simple-smt-tests" ./tests {};
+        simple-smt-z3 = hpkgs.callCabal2nix "simple-smt-z3" ./Z3 {
+          inherit simple-smt-tests;
         };
-      };
-    });
+      in {
+        formatter = pkgs.alejandra;
+
+        devShells = {
+          default = hpkgs.shellFor {
+            packages = p: [
+              simple-smt
+              simple-smt-tests
+              simple-smt-z3
+            ];
+
+            withHoogle = true;
+
+            buildInputs =
+              (with hpkgs; [
+                cabal-install
+                hlint
+                haskell-language-server
+              ])
+              ++ [pkgs.z3];
+
+            ## Needed by the haskell-language-server
+            shellHook = ''
+              export LD_LIBRARY_PATH="${pkgs.z3.lib}/lib:''${LD_LIBRARY_PATH:+:}"
+            '';
+          };
+        };
+      });
 }

--- a/hie.yaml
+++ b/hie.yaml
@@ -1,0 +1,10 @@
+cradle:
+  cabal:
+    - path: "./Z3/src"
+      component: "simple-smt-z3:libs"
+    - path: "./Z3/tests"
+      component: "simple-smt-z3:tests"
+    - path: "./src/"
+      component: "simple-smt:libs"
+    - path: "./tests/"
+      component: "simple-smt:tests"


### PR DESCRIPTION
This PR adds a flake to the repository, and a `hie` file to setup the language server.

The flake is not fully operational because, if I understand correctly, `callCabal2nix` (which is used to transform cabal dependencies into Nix dependencies) fails on `simple-smt-z3` because its tests use `simple-smt-tests`, but the latter is not a library.